### PR TITLE
Updated the Add Key Pair functionality.  

### DIFF
--- a/modules/cloud_service_providers/aws_cloud/aws_cloud.module
+++ b/modules/cloud_service_providers/aws_cloud/aws_cloud.module
@@ -11,6 +11,7 @@
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\aws_cloud\Aws\Ec2\KeyPairInterface;
 
 /**
  * Implements hook_libraries_info()
@@ -118,6 +119,22 @@ function aws_cloud_entity_type_alter(array &$entity_types) {
   // Add aws constraint to cloud_server_template.
   // This constraint will perform AWS specific validations
   $entity_types['cloud_server_template']->addConstraint('AWSConstraint');
+}
+
+/**
+ * Implements hook_entity_view().
+ */
+function aws_cloud_entity_view(array &$build, \Drupal\aws_cloud\Aws\Ec2\KeyPairInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
+  if ($entity->getEntityTypeId() == 'aws_cloud_key_pair' && $view_mode == 'full') {
+    // if the key is on the server, prompt user to download it
+    if ($entity->getKeyFileLocation() != FALSE) {
+      $url = \Drupal\Core\Url::fromRoute('entity.aws_cloud_key_pair.download', ['cloud_context' => $entity->cloud_context(), 'aws_cloud_key_pair' => $entity->id()])->toString();
+      $messenger = \Drupal::messenger();
+      $messenger->addWarning(t('<a href="@download_link">Download private key</a>.  Once downloaded, the key will be deleted from the server.',
+        ['@download_link' => $url]
+      ));
+    }
+  }
 }
 
 /**

--- a/modules/cloud_service_providers/aws_cloud/aws_cloud.routing.yml
+++ b/modules/cloud_service_providers/aws_cloud/aws_cloud.routing.yml
@@ -438,6 +438,20 @@ entity.aws_cloud_key_pair.canonical:
       aws_cloud_key_pair:
         type: "entity:aws_cloud_key_pair"
 
+entity.aws_cloud_key_pair.download:
+  path: '/clouds/aws_cloud/{cloud_context}/key_pair/{aws_cloud_key_pair}/download'
+  defaults:
+    _controller: '\Drupal\aws_cloud\Controller\Ec2\AWSKeyPairController::downloadKey'
+    _title: 'Download KeyPair'
+  requirements:
+    _permission: 'add aws cloud key pair'
+  options:
+    parameters:
+      cloud_context:
+        type: "entity:cloud_context"
+      aws_cloud_key_pair:
+        type: "entity:aws_cloud_key_pair"
+
 entity.aws_cloud_key_pair.collection:
   path: '/clouds/aws_cloud/{cloud_context}/key_pair'
   defaults:

--- a/modules/cloud_service_providers/aws_cloud/src/Aws/Ec2/KeyPairInterface.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Aws/Ec2/KeyPairInterface.php
@@ -81,7 +81,15 @@ interface KeyPairInterface extends ContentEntityInterface, EntityOwnerInterface 
   /**
    * {@inheritdoc}
    */
-/*
-  public function setCloudContext($cloud_context);
-*/
+  public function getKeyFileLocation();
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getKeyFileName();
+
+  /**
+   * {@inheritdoc}
+   */
+  public function saveKeyFile($key);
 }

--- a/modules/cloud_service_providers/aws_cloud/src/Controller/Ec2/AWSKeyPairController.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Controller/Ec2/AWSKeyPairController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\aws_cloud\Controller\Ec2;
+
+use Drupal\aws_cloud\Aws\Config\ConfigInterface;
+use Drupal\aws_cloud\Entity\Ec2\KeyPair;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Messenger\Messenger;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class AWSKeyPairController extends ControllerBase {
+
+  /**
+   * ApiController constructor.
+   * @param \Drupal\Core\Messenger\Messenger $messenger
+   *  Messanger Object
+   */
+  public function __construct(Messenger $messenger) {
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Dependency Injection.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * @param \Drupal\aws_cloud\Aws\Config\ConfigInterface $cloud_context
+   * @param \Drupal\aws_cloud\Entity\Ec2\KeyPair $aws_cloud_key_pair
+   * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+   */
+  public function downloadKey(ConfigInterface $cloud_context, KeyPair $aws_cloud_key_pair) {
+    $file = $aws_cloud_key_pair->getKeyFileLocation();
+    if ($file != FALSE) {
+      $response = new BinaryFileResponse($file, 200, [], FALSE, 'attachment');
+      $response->setContentDisposition('attachment', $aws_cloud_key_pair->key_pair_name() . '.pem');
+      $response->deleteFileAfterSend(TRUE);
+      return $response;
+    }
+    else {
+      // just redirect to keypair listing page.
+      return $this->redirect('view.aws_cloud_key_pairs.page_1', [
+        'cloud_context' => $cloud_context->id(),
+      ]);
+    }
+  }
+
+}

--- a/modules/cloud_service_providers/aws_cloud/src/Entity/Ec2/KeyPair.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Entity/Ec2/KeyPair.php
@@ -109,6 +109,38 @@ class KeyPair extends CloudContentEntityBase implements KeyPairInterface {
   }
 
   /**
+   * Helper function that returns the file location of the key file.
+   * @return bool|string
+   */
+  public function getKeyFileLocation() {
+    $file = FALSE;
+    if (file_exists(file_directory_temp() . '/' . $this->key_pair_name() . '.pem')) {
+      $file = file_directory_temp() . '/' . $this->key_pair_name() . '.pem';
+    }
+    return $file;
+  }
+
+  /**
+   * Helper function that returns the file location, starting
+   * with stream wrapper URI
+   * @return string
+   */
+  public function getKeyFileName() {
+    return 'temporary://' . $this->key_pair_name() . '.pem';
+  }
+
+  /**
+   * Helper function to save private key to temporary file system
+   * @param $key
+   *  String of the private key
+   */
+  public function saveKeyFile($key) {
+    if (!empty($key)) {
+      file_unmanaged_save_data($key, $this->getKeyFileName());
+    }
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {


### PR DESCRIPTION
Following AWS's documentation and not storing the private key in the database.  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html

The key pair is written to a temporary file.  The user gets a prompt to download it once they create a new key pair.  Upon download, the file is deleted.