### PR TITLE
Fixing entity updates and cron runs.

### DIFF
--- a/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2ServiceInterface.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2ServiceInterface.php
@@ -313,7 +313,7 @@ interface AwsEc2ServiceInterface {
    *    FALSE if nothing is updated.  Number of images imported returned as
    *    integer if successful
    */
-  public function updateImages($params = [], $clear = TRUE);
+  public function updateImages($params = [], $clear = FALSE);
 
   /**
    * Update the Ec2 Security Groups.  Delete old Security Groups entities,
@@ -355,6 +355,8 @@ interface AwsEc2ServiceInterface {
    * Update the Ec2 Volumes.  Delete old Volumes entities,
    * query the api for updated entities and store them as Volumes entities.
    *
+   * @params boolean $clear
+   *   TRUE to delete images entities before importing
    *  @return boolean
    *    indicates success so failure
    */
@@ -364,6 +366,8 @@ interface AwsEc2ServiceInterface {
    * Update the Ec2 snapshots.  Delete old snapshots entities,
    * query the api for updated entities and store them as snapshots entities.
    *
+   * @params boolean $clear
+   *   TRUE to delete images entities before importing
    *  @return boolean
    *    indicates success so failure
    */


### PR DESCRIPTION
Fixing entity updates and cron runs.  Instead of deleting all entities and starting over, adding logic to update existing entities, and then deleting entities that are not returned from the API calls.

The issue with deleting all entities and starting again is that Cloud Server Templates uses entity reference to SSH keys, groups, networks.  If we delete them and reimport, the entity references will be orphaned and the templates won't launch with the parameters specified by the user.