### PR TITLE
Adding capability to store an instance name as a tag in AWS. 

### DIFF
--- a/modules/cloud_service_providers/aws_cloud/src/Aws/Ec2/InstanceInterface.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Aws/Ec2/InstanceInterface.php
@@ -313,7 +313,6 @@ interface InstanceInterface extends ContentEntityInterface, EntityOwnerInterface
   /**
    * {@inheritdoc}
    */
-/*
-  public function setCloudContext($cloud_context);
-*/
+  public function setName($name);
+
 }

--- a/modules/cloud_service_providers/aws_cloud/src/Entity/Ec2/Instance.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Entity/Ec2/Instance.php
@@ -483,6 +483,13 @@ class Instance extends CloudContentEntityBase implements InstanceInterface {
   /**
    * {@inheritdoc}
    */
+  public function setName($name) {
+    return $this->set('name', $name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
 
     $fields['id'] = BaseFieldDefinition::create('integer')

--- a/modules/cloud_service_providers/aws_cloud/src/Form/Ec2/InstanceEditForm.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Form/Ec2/InstanceEditForm.php
@@ -4,7 +4,6 @@
 // Created by yas 2016/05/30.
 namespace Drupal\aws_cloud\Form\Ec2;
 
-use Drupal\cloud\Form\CloudContentForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\Language;
 
@@ -13,7 +12,7 @@ use Drupal\Core\Language\Language;
  *
  * @ingroup aws_cloud
  */
-class InstanceEditForm extends CloudContentForm {
+class InstanceEditForm extends AwsCloudContentForm {
 
   /**
    * Overrides Drupal\Core\Entity\EntityFormController::buildForm().
@@ -171,6 +170,26 @@ class InstanceEditForm extends CloudContentForm {
     $form['actions'] = $this->actions($form, $form_state, $cloud_context);
 
     return $form;
+  }
+
+  /**
+   * {@inheritdocs}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    parent::save($form, $form_state);
+
+    // update the instance name - it is a tag
+    $params = [
+      'Resources' => [$this->entity->get('instance_id')->value],
+      'Tags' => [
+        [
+          'Key' => 'cloud_instance_nickname',
+          'Value' => $this->entity->get('name')->value
+        ],
+      ]
+    ];
+    $this->awsEc2Service->setCloudContext($this->entity->get('cloud_context')->value);
+    $this->awsEc2Service->createTags($params);
   }
 
 }

--- a/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2Service.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2Service.php
@@ -265,6 +265,12 @@ class AwsEc2Service implements AwsEc2ServiceInterface {
     return $results;
   }
 
+  public function createTags($params = []) {
+    $params += $this->getDefaultParameters();
+    $results = $this->execute('CreateTags', $params);
+    return $results;
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -531,7 +537,7 @@ class AwsEc2Service implements AwsEc2ServiceInterface {
 
           $instanceName = '';
           foreach ($instance['Tags'] as $tag) {
-            if ($tag['Key'] == 'Name') {
+            if ($tag['Key'] == 'cloud_instance_nickname') {
               $instanceName = $tag['Value'];
             }
           }
@@ -545,6 +551,7 @@ class AwsEc2Service implements AwsEc2ServiceInterface {
           // Skip if $entity already exists, by updating 'refreshed' time.
           if (!empty($entity_id)) {
             $entity = Instance::load($entity_id);
+            $entity->setName($instanceName);
             $entity->setInstanceState($instance['State']['Name']);
             $entity->setElasticIp($instance['elastic_ip']);
             $entity->setRefreshed($timestamp);
@@ -635,28 +642,28 @@ class AwsEc2Service implements AwsEc2ServiceInterface {
         }
 
         $entity = Image::create([
-          // $cloud_context,.
-          'cloud_context'       => $this->cloud_context,
-          'image_id'            => $image['ImageId'],
-          'owner'               => $image['OwnerId'],
-          'architecture'        => $image['Architecture'],
+          'cloud_context' => $this->cloud_context,
+          'image_id' => $image['ImageId'],
+          'owner' => $image['OwnerId'],
+          'architecture' => $image['Architecture'],
           'virtualization_type' => $image['VirtualizationType'],
-          'root_device_type'    => $image['RootDeviceType'],
-          'root_device_name'    => $image['RootDeviceName'],
-          'ami_name'            => $image['Name'],
-          'kernel_id'           => $image['KernelId'],
-          'ramdisk_id'          => $image['RamdiskId'],
-          'image_type'          => $image['ImageType'],
-          'product_code'        => $image['product_code'],
-          'source'              => $image['ImageLocation'],
-          'state_reason'        => $image['StateReason']['Message'],
-          'platform'            => $image['Platform'],
-          'description'         => $image['Description'],
-          'visibility'          => $image['Public'],
-          'block_devices'       => implode(', ', $block_devices),
-          'created'             => strtotime($image['CreationDate']),
-          'changed'             => $timestamp,
-          'refreshed'           => $timestamp,
+          'root_device_type' => $image['RootDeviceType'],
+          'root_device_name' => $image['RootDeviceName'],
+          'ami_name' => $image['Name'],
+          'name' => $image['Name'],
+          'kernel_id' => $image['KernelId'],
+          'ramdisk_id'  => $image['RamdiskId'],
+          'image_type' => $image['ImageType'],
+          'product_code' => $image['product_code'],
+          'source' => $image['ImageLocation'],
+          'state_reason' => $image['StateReason']['Message'],
+          'platform' => $image['Platform'],
+          'description' => $image['Description'],
+          'visibility' => $image['Public'],
+          'block_devices' => implode(', ', $block_devices),
+          'created' => strtotime($image['CreationDate']),
+          'changed' => $timestamp,
+          'refreshed' => $timestamp,
         ]);
         $entity->save();
       }

--- a/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2ServiceInterface.php
+++ b/modules/cloud_service_providers/aws_cloud/src/Service/AwsEc2ServiceInterface.php
@@ -80,6 +80,16 @@ interface AwsEc2ServiceInterface {
   public function createSecurityGroup($params = []);
 
   /**
+   * Calls the Ec2 API endpoint Create Tags.
+   *
+   * @param array $params
+   *   Parameters array to send to API
+   * @throws \Drupal\aws_cloud\Service\AwsEc2ServiceException
+   */
+  public function createTags($params = []);
+
+
+  /**
    * Calls the Ec2 API endpoint DeregisterImage.
    *
    * @param array $params


### PR DESCRIPTION
This way, when the "name" is changed in orchestrator, it will persist in AWS.

Subsequently, if the instance is updated in orchestrator, the name will come back during the update process.